### PR TITLE
Add section "Versioning and Support Policy"

### DIFF
--- a/index.html
+++ b/index.html
@@ -289,6 +289,12 @@
             <li><a href="https://learn.microsoft.com/en-us/azure/aks/best-practices-performance-scale" target="_blank">Small and Medium Workloads</a></li>
             <li><a href="https://learn.microsoft.com/en-us/azure/aks/best-practices-performance-scale-large" target="_blank">Large Workloads</a></li>
         </ul>
+        <h3>Versioning and Support Policy</h3>
+        <ul>
+            <li><a href="https://learn.microsoft.com/en-us/azure/aks/support-policies" target="_blank">General Support Policy</a></li>
+            <li><a href="https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions" target="_blank">AKS Version Support</a></li>
+            <li><a href="https://learn.microsoft.com/en-us/azure/aks/release-tracker" target="_blank">Release Tracker</a></li>
+        </ul>
     </div>
 
     <div class="footer">


### PR DESCRIPTION
**Proposed change**:
Adding some articles referring to AKS support policy with versioning control

**Supporting point:**
1. In reality, many users continue to use outdated versions due to laziness or unnecessary. However, when seeking support from Azure for any encountered bugs, the version must be on the support list in nearly all cases. 
2. "Release tracker" document page already includes both deployment process and release notes. So I believe that one link should suffice enough - to avoid too many links in one page. 